### PR TITLE
Add backend multi-module Spring Boot app and CI quality job (ktlint + build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,30 +3,31 @@
 # ================================================================
 # PR:
 #   1. Проверка оформления PR
+#   2. Backend: ktlint
+#   3. Backend: build
 #
 # Push в master:
 #   1. Проверка commit message (MERGED: ...)
+#   2. Backend: ktlint
+#   3. Backend: build
 # ================================================================
 
 name: CI Pipeline
 
 on:
   pull_request:
-    types: [ opened, edited, reopened, synchronize ]
+    types: [opened, edited, reopened, synchronize]
   push:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
-  ci:
+  validate-metadata:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # ------------------------------------------------
-      # PR validation
-      # ------------------------------------------------
       - name: Check Pull Request format
         if: github.event_name == 'pull_request'
         env:
@@ -34,9 +35,30 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: bash scripts/check_pr.sh
 
-      # ------------------------------------------------
-      # Commit validation (master)
-      # ------------------------------------------------
       - name: Check commit message
         if: github.event_name == 'push'
         run: bash scripts/check_commit.sh
+
+  backend-quality:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run ktlint checks
+        run: gradle ktlintCheck
+        working-directory: backend
+
+      - name: Build backend
+        run: gradle build
+        working-directory: backend

--- a/backend/app/build.gradle.kts
+++ b/backend/app/build.gradle.kts
@@ -1,0 +1,18 @@
+apply(plugin = "org.springframework.boot")
+apply(plugin = "io.spring.dependency-management")
+apply(plugin = "org.jetbrains.kotlin.plugin.spring")
+
+dependencies {
+    implementation(project(":auth"))
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/backend/app/src/main/kotlin/com/company/vaccination/Application.kt
+++ b/backend/app/src/main/kotlin/com/company/vaccination/Application.kt
@@ -1,0 +1,19 @@
+package com.company.vaccination
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@SpringBootApplication
+class Application
+
+fun main(args: Array<String>) {
+    runApplication<Application>(*args)
+}
+
+@RestController
+class HealthController {
+    @GetMapping("/health")
+    fun health(): Map<String, String> = mapOf("status" to "ok")
+}

--- a/backend/app/src/main/resources/application.yml
+++ b/backend/app/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  application:
+    name: employee-vaccination-app
+
+server:
+  port: 8080

--- a/backend/auth/build.gradle.kts
+++ b/backend/auth/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    implementation(kotlin("stdlib"))
+}

--- a/backend/auth/src/main/kotlin/com/company/vaccination/auth/AuthModule.kt
+++ b/backend/auth/src/main/kotlin/com/company/vaccination/auth/AuthModule.kt
@@ -1,0 +1,3 @@
+package com.company.vaccination.auth
+
+class AuthModule

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,0 +1,33 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:3.4.3")
+        classpath("io.spring.gradle:dependency-management-plugin:1.1.7")
+        classpath("org.jlleitschuh.gradle:ktlint-gradle:12.1.2")
+    }
+}
+
+allprojects {
+    group = "com.company.vaccination"
+    version = "0.0.1-SNAPSHOT"
+
+    repositories {
+        mavenCentral()
+    }
+}
+
+subprojects {
+    apply(plugin = "org.jetbrains.kotlin.jvm")
+    apply(plugin = "org.jlleitschuh.gradle.ktlint")
+
+    tasks.withType<KotlinCompile>().configureEach {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+        }
+    }
+}

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,0 +1,2 @@
+kotlin.code.style=official
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8

--- a/backend/settings.gradle.kts
+++ b/backend/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "employee-vaccination-backend"
+
+include("app")
+include("auth")


### PR DESCRIPTION
### Motivation

- Introduce a basic backend multi-module Gradle project with a runnable Spring Boot application and a simple health endpoint for service readiness checks.
- Enforce code quality and build verification for the backend by adding ktlint and build steps to the CI pipeline.

### Description

- Added a new `backend` Gradle multi-module project with `settings.gradle.kts`, `gradle.properties`, and a root `build.gradle.kts` that configures Kotlin, Spring Boot, and `ktlint` for subprojects.
- Created `app` module with `build.gradle.kts`, `Application.kt` exposing a `/health` endpoint, and `application.yml` to configure the application name and server port.
- Created `auth` module placeholder with a small `AuthModule` class and minimal dependencies.
- Updated `.github/workflows/ci.yml` to add a `backend-quality` job that sets up JDK 21 and Gradle and runs `gradle ktlintCheck` and `gradle build` in the `backend` directory, while keeping PR metadata and commit message checks.

### Testing

- No automated test runs were executed as part of this PR itself.
- The new CI job is configured to run `gradle ktlintCheck` and `gradle build` in `backend`, which will execute linting and the build (including unit tests) when the workflow runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3728f93f08323a4c046ad4156461a)